### PR TITLE
Command_CleanupTarget - added rounding to 0.01f (1%)

### DIFF
--- a/Source/AOMoreFurniture/Command_CleanupTarget.cs
+++ b/Source/AOMoreFurniture/Command_CleanupTarget.cs
@@ -22,7 +22,7 @@ namespace VanillaFurnitureEC
             Widgets.Label(labelRect, "VFE.SetTargetCleanup".Translate(comp.cleanupTarget.ToStringPercent()));
             Text.Anchor = TextAnchor.UpperLeft;
             var sliderRect = new Rect(labelRect.x, labelRect.yMax, labelRect.width, 24);
-            comp.cleanupTarget = Widgets.HorizontalSlider_NewTemp(sliderRect, comp.cleanupTarget, 0, 1);
+            comp.cleanupTarget = Widgets.HorizontalSlider_NewTemp(sliderRect, comp.cleanupTarget, 0, 1, roundTo: 0.01f);
             return new GizmoResult(GizmoState.Clear);
         }
     }


### PR DESCRIPTION
A minor change. Should prevent situations where cleanup at (for example) 50% would not happen due to the actual being slightly larger (0.5001) but rounded down by the call to `ToStringPercent`.