### PR TITLE
Replace CompBinClean counter with IsHashIntervalTick call

### DIFF
--- a/Source/AOMoreFurniture/Comps/CompBinClean.cs
+++ b/Source/AOMoreFurniture/Comps/CompBinClean.cs
@@ -9,8 +9,6 @@ namespace VanillaFurnitureEC
     {
         public CompProperties_BinClean Props => (CompProperties_BinClean)props;
 
-        private int ticksCounted = 0;
-
         public ThingOwner innerContainer;
 
         public float cleanupTarget = 0.9f;
@@ -37,7 +35,7 @@ namespace VanillaFurnitureEC
 
         public override void CompTick()
         {
-            if (ticksCounted == Props.timerInTicks)
+            if (AmountStoredPct < 1f && parent.IsHashIntervalTick(Props.timerInTicks))
             {
                 var filthInHomeArea = parent.Map.listerFilthInHomeArea.FilthInHomeArea;
                 for (int i = 0; i < filthInHomeArea.Count; i++)
@@ -53,9 +51,7 @@ namespace VanillaFurnitureEC
                         }
                     }
                 }
-                ticksCounted = 0;
             }
-            ticksCounted++;
         }
 
         public override void PostDestroy(DestroyMode mode, Map previousMap)
@@ -86,14 +82,7 @@ namespace VanillaFurnitureEC
             }
         }
 
-        private bool CanAccept(Filth filth)
-        {
-            if (AmountStoredPct < 1f)
-            {
-                return Props.capacity - AmountStored >= filth.thickness;
-            }
-            return false;
-        }
+        private bool CanAccept(Filth filth) => Props.capacity - AmountStored >= filth.thickness;
 
         public void GetChildHolders(List<IThingHolder> outChildren)
         {


### PR DESCRIPTION
Multiple bins would end up with the same counter value when reloading the game, or when multiple bins were spawned on the same tick. This could end up in lag spikes when all bins performed their operations on the same tick.

On top of that, the code was iterating over all spawned filth in home area even if the bin was full.

This PR should fix that by:
- Removing the counter
- Checking if the operation should be performed using `IsHashIntervalTick`
- Checking beforehand if the bin is not full

On top of that, `CanAccept` method no longer checks if the bin is full as:
- The method calling it now does it before calling it
- It would still return `false` if it was full