### PR TITLE
Modify WorkGiver_CleanBin to use a list of defs with bin cleaning comp

### DIFF
--- a/Source/AOMoreFurniture/StaticCollections.cs
+++ b/Source/AOMoreFurniture/StaticCollections.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Verse;
+
+namespace VanillaFurnitureEC
+{
+    [StaticConstructorOnStartup]
+    public static class StaticCollections
+    {
+        public static List<ThingDef> compBinCleanDefs = DefDatabase<ThingDef>.AllDefsListForReading
+            .Where(def => def.comps.Any(comp => comp is CompProperties_BinClean)).ToList();
+    }
+}

--- a/Source/AOMoreFurniture/VanillaFurnitureEC.csproj
+++ b/Source/AOMoreFurniture/VanillaFurnitureEC.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Comps\CompBinClean.cs" />
     <Compile Include="Comps\CompProperties_BinClean.cs" />
     <Compile Include="JobDriver_CleanBin.cs" />
+    <Compile Include="StaticCollections.cs" />
     <Compile Include="WorkGiver_CleanBin.cs" />
     <Compile Include="StatPart_Bin.cs" />
     <Compile Include="EffecterDefOf.cs" />

--- a/Source/AOMoreFurniture/WorkGiver_CleanBin.cs
+++ b/Source/AOMoreFurniture/WorkGiver_CleanBin.cs
@@ -1,6 +1,5 @@
 ﻿using RimWorld;
 using System.Collections.Generic;
-using System.Linq;
 using Verse;
 using Verse.AI;
 
@@ -12,16 +11,10 @@ namespace VanillaFurnitureEC
         public override IEnumerable<Thing> PotentialWorkThingsGlobal(Pawn pawn)
         {
             var list = new List<Thing>();
-            var smallBin = DefDatabase<ThingDef>.GetNamedSilentFail("Bin_Small");
-            if (smallBin != null)
-            {
-                list.AddRange(pawn.Map.listerThings.ThingsOfDef(smallBin));
-            }
-            var largeBin = DefDatabase<ThingDef>.GetNamedSilentFail("Bin_Large");
-            if (largeBin != null)
-            {
-                list.AddRange(pawn.Map.listerThings.ThingsOfDef(largeBin));
-            }
+
+            foreach (var binDef in StaticCollections.compBinCleanDefs)
+                list.AddRange(pawn.Map.listerThings.ThingsOfDef(binDef));
+
             return list;
         }
 


### PR DESCRIPTION
Changes introduced in this PR:
- Added `StaticCollections` class, which hold a list of all `ThingDef`s which have `CompBinClean`
- `WorkGiver_CleanBin.PotentialWorkThingsGlobal` will now use that list
  - Compared to previous implementation, bins added by other mods will be supported
  - It doesn't require a lookup to `DefDatabase`