### PR TITLE
Update linkFlags for modular benches

### DIFF
--- a/1.6/Defs/Buildings_Furniture/Buildings_BasicSeats.xml
+++ b/1.6/Defs/Buildings_Furniture/Buildings_BasicSeats.xml
@@ -52,7 +52,7 @@
       <graphicClass>Graphic_Single</graphicClass>
       <linkType>Basic</linkType>
       <linkFlags>
-        <li>Custom7</li>
+        <li>VFE_Benches</li>
       </linkFlags>
       <damageData>
         <rect>(0.30,0.15,0.4,0.6)</rect>


### PR DESCRIPTION
Modular benches are linking with things like ancientpipes and airducts from temperature expanded because they also use custom7

If you have a airduct running underneath or next to benches they now link to them, that is definitely not supposed to happen.

So giving a unique name to the link flag for benches causes them to only interact with themselves which is the safest option I reckon