### PR TITLE
Change link flag from Custom7 to Custom9

### DIFF
--- a/1.6/Defs/Buildings_Furniture/Buildings_BasicSeats.xml
+++ b/1.6/Defs/Buildings_Furniture/Buildings_BasicSeats.xml
@@ -52,7 +52,7 @@
       <graphicClass>Graphic_Single</graphicClass>
       <linkType>Basic</linkType>
       <linkFlags>
-        <li>Custom7</li>
+        <li>Custom9</li>
       </linkFlags>
       <damageData>
         <rect>(0.30,0.15,0.4,0.6)</rect>


### PR DESCRIPTION
Custom7 is used by all kinds of pipenetworks and it caused the benches to link to network (hidden or not) piping, in particular in the case I noticed from Temperature Expanded's airducts which I had run across a wall with benches next to it which suddenly linked to them very awkwardly.

Theoretically any other Custom# (1 to 10, but not 7 or 8) should be fine depending on which ones are used elsewhere by modders and internally by VE.

I just set it to 9 since it is unused in vanilla and I am not aware of anyone using 9 at the moment.